### PR TITLE
Refactored your PR

### DIFF
--- a/doc/basics-reference.markdown
+++ b/doc/basics-reference.markdown
@@ -339,7 +339,7 @@ implemented, though, so generator methods are not available.
     (object
         ('prop)
         ((. Symbol 'toStringTag) "foo")
-        ('method (arg) (return (+ arg 1)))
+        (method 'methodName (arg) (return (+ arg 1)))
         (get data () (return 1)))
 
 <!-- !test out object es6 -->
@@ -349,7 +349,7 @@ implemented, though, so generator methods are not available.
     ({
         prop,
         [Symbol.toStringTag]: 'foo',
-        method(arg) {
+        methodName(arg) {
             return arg + 1;
         },
         get [data]() {

--- a/doc/basics-reference.markdown
+++ b/doc/basics-reference.markdown
@@ -374,7 +374,7 @@ Property access uses the `.` macro.
 If you wish you could just write those as `a.b.c` in eslisp code, use the
 [*eslisp-propertify*][10] user-macro.
 
-For *computed* property access, omit the leading colon.
+For *computed* property access, omit the quote.
 
 <!-- !test in computed property access macro -->
 

--- a/makefile
+++ b/makefile
@@ -26,4 +26,4 @@ test-docs: all doc/how-macros-work.markdown doc/basics-reference.markdown
 
 test-all: test test-readme test-docs
 
-.PHONY: all clean test test-readme test-docs
+.PHONY: all clean test test-readme test-docs test-all

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -203,7 +203,7 @@ contents =
     class ObjectParamError extends Error
       (@message) ~>
 
-    compile-get-set = (kind, [name, params, ...body]) ->
+    compile-get-set = (kind, [name, ...function-macro-arguments-part]) ->
       # kind is either "get" or "set"
 
       # What the thing being compiled is called in human-readable errors
@@ -217,6 +217,10 @@ contents =
       name = @compile node
       if name.kind is \Literal
         computed := false
+
+      # We'll only check the parameters here; the function expression macro can
+      # check the body.
+      [ params, _ ] = function-macro-arguments-part
 
       unless is-list params
         throw ObjectParamError "Expected #readable-kind-name to have a \
@@ -249,12 +253,10 @@ contents =
       key : name
       # The initial check doesn't cover the compiled case.
       computed : computed
-      value :
-        type : \FunctionExpression
-        id : null
-        params : params
-        body : optionally-implicit-block-statement this, body
-        expression : false
+      value : do
+        (function-type \FunctionExpression)
+          .apply this, function-macro-arguments-part
+            ..expression = false
 
     compile-method = ([name, params, ...body]) ->
       if not name?

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -101,7 +101,7 @@ function-type = (type) -> (params, ...rest) ->
 
 is-atom = (node, name) -> node.type is \atom and node.value is name
 
-unwrap-quote = (node, string-is-computed) ->
+unwrap-quote = (node) ->
   | node.type is \list and node.values.0 `is-atom` \quote =>
     computed : false
     node : node.values.1
@@ -204,7 +204,7 @@ contents =
       if not name?
         throw Error "Expected #{type}ter in property #i to have a name"
 
-      {node, computed} = unwrap-quote name, true
+      {node, computed} = unwrap-quote name
 
       unless computed or node.type is \atom
         throw Error "Expected name of #{type}ter in property #i to be a quoted
@@ -253,7 +253,7 @@ contents =
       if not name?
         throw Error "Expected method in property #i to have a name"
 
-      {node, computed} = unwrap-quote name, true
+      {node, computed} = unwrap-quote name
 
       unless computed or node.type is \atom
         throw Error "Expected name of method in property #i to be a quoted atom
@@ -311,7 +311,7 @@ contents =
         shorthand : true
 
       | args.length is 2 =>
-        {node, computed} = unwrap-quote args.0, true
+        {node, computed} = unwrap-quote args.0
 
         if not computed and node.type isnt \atom
           throw Error "Expected name of property #i to be an expression or
@@ -433,7 +433,7 @@ contents =
 
   \. : do
     join-members = (host, prop) ->
-      {node, computed} = unwrap-quote prop, false
+      {node, computed} = unwrap-quote prop
 
       if not computed and node.type isnt \atom
         throw Error "Expected quoted name of property getter to be an atom"

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -123,15 +123,6 @@ maybe-unwrap-quote = (node) ->
     computed : true
     node     : node
 
-# For some final coercion after compilation, when building the ESTree AST.
-coerce-property = (node, computed) ->
-  # This should be explicitly overridden and unconditional. Helps with
-  # minifiers and other things.
-  | node.type is \Literal =>
-    node : node
-    computed : false
-  | otherwise => { node, computed }
-
 contents =
   \+ : n-ary-expr \+
   \- : n-ary-expr \-
@@ -214,7 +205,9 @@ contents =
 
       {node, computed} = maybe-unwrap-quote name
 
-      {node : name, computed} = coerce-property (@compile node), computed
+      name = @compile node
+      if name.type is \Literal
+        computed := false
       kind = infer-name "#{type}ter", name, computed
 
       unless params?.type is \list
@@ -259,7 +252,9 @@ contents =
 
       {node, computed} = maybe-unwrap-quote name
 
-      {node : name, computed} = coerce-property (@compile node), computed
+      name := @compile node
+      if name.type is \Literal
+        computed := false
       method = infer-name 'method', name, computed
 
       if not params? or params.type isnt \list
@@ -313,7 +308,9 @@ contents =
       | args.length is 2 =>
         {node, computed} = maybe-unwrap-quote args.0
 
-        {node : key, computed} = coerce-property (@compile node), computed
+        key = @compile node
+        if key.type is \Literal
+          computed := false
 
         type : \Property
         kind : \init

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -250,9 +250,11 @@ contents =
           .apply this, function-macro-arguments-part
             ..expression = false
 
-    compile-method = ([name, params, ...body]) ->
-      if not name?
-        throw ObjectParamError "Expected method to have a name"
+    compile-method = ([name, ...function-macro-arguments-part]) ->
+
+      if not name? then throw ObjectParamError "Expected method to have a name"
+
+      [ params, _ ] = function-macro-arguments-part
 
       {node, computed} = maybe-unwrap-quote name
 
@@ -264,28 +266,19 @@ contents =
                                      | true  => " '#{name.name}'"
                                      | false => ""
 
-      if not params? or params.type isnt \list
-        throw ObjectParamError "Expected #readable-kind-name to have a parameter \
-                     list"
-
-      params = for param, j in params.values
-        if param.type isnt \atom
-          throw ObjectParamError "Expected parameter #j for #readable-kind-name
-                                  to be an identifier"
-        type : \Identifier
-        name : param.value
+      if not params? or not is-list params
+        throw ObjectParamError "Expected #readable-kind-name to have a \
+                                parameter list"
 
       type : \Property
       kind : \init
       method : true
       computed : computed
       key : name
-      value :
-        type : \FunctionExpression
-        id : null
-        params : params
-        body : optionally-implicit-block-statement this, body
-        expression : false
+      value : do
+        (function-type \FunctionExpression)
+          .apply this, function-macro-arguments-part
+            ..expression = false
 
     compile-property-list = (args) ->
       | args.length is 0 =>

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -232,12 +232,11 @@ contents =
       # Catch this error here, to return a more sensible, helpful error message
       # than merely an InvalidAstError referencing property names from the
       # stringifier itself.
-      if kind is \get
-        if params.length isnt 0
+      switch
+      | kind is \get and params.length isnt 0
           throw ObjectParamError "Expected #readable-kind-name to have \
                                   no parameters (got #{params.length})"
-      else # kind is \set
-        if params.length isnt 1
+      | kind is \set and params.length isnt 1
           throw ObjectParamError "Expected #readable-kind-name to have \
                                   exactly one parameter (got #{params.length})"
 

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -223,8 +223,9 @@ contents =
       [ params, _ ] = function-macro-arguments-part
 
       unless is-list params
-        throw ObjectParamError "Expected #readable-kind-name to have a \
-                                parameter list"
+        throw ObjectParamError "Unexpected #readable-kind-name part \
+                                (got #{params.type}; \
+                                expected list of parameters)"
 
       params .= values
 

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -116,12 +116,10 @@ maybe-unwrap-quote = (node) ->
     node : node
 
 # For some final coercion after compilation, when building the ESTree AST.
-coerce-property = (node, computed, string-is-computed) ->
-  # This should be explicitly overridden and unconditional. Helps with minifiers
-  # and other things.
-  | string-is-computed and
-      node.type is \Literal and
-      typeof node.value isnt \object =>
+coerce-property = (node, computed) ->
+  # This should be explicitly overridden and unconditional. Helps with
+  # minifiers and other things.
+  | (node.type is \Literal) and (typeof node.value isnt \object) =>
     node :
       type : \Literal
       value : node.value + ''
@@ -216,7 +214,7 @@ contents =
         throw Error "Expected name of #{type}ter in property #i to be a quoted
           atom or an expression"
 
-      {node : name, computed} = coerce-property (@compile node), computed, true
+      {node : name, computed} = coerce-property (@compile node), computed
       kind = infer-name "#{type}ter", name, computed
 
       unless params?.type is \list
@@ -265,7 +263,7 @@ contents =
         throw Error "Expected name of method in property #i to be a quoted atom
           or an expression"
 
-      {node : name, computed} = coerce-property (@compile node), computed, true
+      {node : name, computed} = coerce-property (@compile node), computed
       method = infer-name 'method', name, computed
 
       if not params? or params.type isnt \list
@@ -323,7 +321,7 @@ contents =
           throw Error "Expected name of property #i to be an expression or
             quoted atom"
 
-        {node : key, computed} = coerce-property (@compile node), computed, true
+        {node : key, computed} = coerce-property (@compile node), computed
 
         type : \Property
         kind : \init

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -341,6 +341,7 @@ contents =
         compile-get-set.call this, args.0.value, args[1 til]
 
       # Reserve this for future generator use.
+      # TODO Implement
       | args.0 `is-atom` \* =>
         throw ObjectParamError "Unexpected '*' (generator methods not yet implemented)"
 

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -119,14 +119,10 @@ maybe-unwrap-quote = (node) ->
 coerce-property = (node, computed) ->
   # This should be explicitly overridden and unconditional. Helps with
   # minifiers and other things.
-  | (node.type is \Literal) and (typeof node.value isnt \object) =>
-    node :
-      type : \Literal
-      value : node.value + ''
-    computed : false
-  | otherwise =>
+  | node.type is \Literal =>
     node : node
-    computed : computed
+    computed : false
+  | otherwise => { node, computed }
 
 contents =
   \+ : n-ary-expr \+

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -99,13 +99,19 @@ function-type = (type) -> (params, ...rest) ->
   params : params
   body : optionally-implicit-block-statement this, rest
 
-is-atom = (node, name) -> node.type is \atom and node.value is name
+is-atom = (node, name) ->
+  type-ok  = node.type is \atom
+  value-ok = if name then (node.value is name) else true
+
+  type-ok and value-ok
+
+is-list = (node) -> node.type is \list
 
 maybe-unwrap-quote = (node) ->
-  | node.type is \list and node.values.0 `is-atom` \quote =>
+  if (is-list node) and (is-atom node.values.0, \quote)
     computed : false
     node : node.values.1
-  | otherwise =>
+  else
     computed : true
     node : node
 

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -187,9 +187,6 @@ contents =
     elements : elements.map @compile
 
   \object : do
-    check-list = (list, i) ->
-      | list? and list.type is \list => list.values
-      | otherwise => throw Error "Expected property #i to be a list"
 
     infer-name = (prefix, name, computed) ->
       if computed
@@ -330,10 +327,16 @@ contents =
 
       | otherwise => compile-method.call this, i, args
 
-    ->
+    (...args) ->
       type : \ObjectExpression
-      properties : for args, i in arguments
-        compile-list.call this, i, (check-list args, i)
+      properties : args.map (arg, i) ~>
+
+        if is-list arg
+          compile-list.call @, i, arg.values
+        else
+          throw Error "Unexpected argument to object macro: \
+                       expected properties to be lists, but \
+                       argument #i type was #{arg.type}"
 
   \var : (name, value) ->
     if &length > 2

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -240,14 +240,6 @@ contents =
         if params.length isnt 1
           throw ObjectParamError "Expected #readable-kind-name to have \
                                   exactly one parameter (got #{params.length})"
-        param = params.0
-        if not is-atom param
-          throw ObjectParamError "Expected parameter for \
-                                  #readable-kind-name to be an identifier"
-        params = [
-          type : \Identifier
-          name : param.value
-        ]
 
       type : \Property
       kind : kind

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -235,11 +235,11 @@ contents =
       if kind is \get
         if params.length isnt 0
           throw ObjectParamError "Expected #readable-kind-name to have \
-                                  no parameters"
+                                  no parameters (got #{params.length})"
       else # kind is \set
         if params.length isnt 1
           throw ObjectParamError "Expected #readable-kind-name to have \
-                                  exactly one parameter"
+                                  exactly one parameter (got #{params.length})"
         param = params.0
         if not is-atom param
           throw ObjectParamError "Expected parameter for \

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -109,11 +109,19 @@ is-list = (node) -> node.type is \list
 
 maybe-unwrap-quote = (node) ->
   if (is-list node) and (is-atom node.values.0, \quote)
+
+    quoted-thing = node.values.1
+
+    unless is-atom quoted-thing
+      throw Error "Unexpected quoted property #{quoted-thing.type}: \
+                   expected atom"
+
     computed : false
-    node : node.values.1
+    node     : quoted-thing
+
   else
     computed : true
-    node : node
+    node     : node
 
 # For some final coercion after compilation, when building the ESTree AST.
 coerce-property = (node, computed) ->
@@ -206,10 +214,6 @@ contents =
 
       {node, computed} = maybe-unwrap-quote name
 
-      unless computed or node.type is \atom
-        throw Error "Expected name of #{type}ter in property #i to be a quoted
-          atom or an expression"
-
       {node : name, computed} = coerce-property (@compile node), computed
       kind = infer-name "#{type}ter", name, computed
 
@@ -254,10 +258,6 @@ contents =
         throw Error "Expected method in property #i to have a name"
 
       {node, computed} = maybe-unwrap-quote name
-
-      unless computed or node.type is \atom
-        throw Error "Expected name of method in property #i to be a quoted atom
-          or an expression"
 
       {node : name, computed} = coerce-property (@compile node), computed
       method = infer-name 'method', name, computed
@@ -312,10 +312,6 @@ contents =
 
       | args.length is 2 =>
         {node, computed} = maybe-unwrap-quote args.0
-
-        if not computed and node.type isnt \atom
-          throw Error "Expected name of property #i to be an expression or
-            quoted atom"
 
         {node : key, computed} = coerce-property (@compile node), computed
 
@@ -438,9 +434,6 @@ contents =
       host = @compile host-node
 
       { node : prop-node, computed } = maybe-unwrap-quote prop-node
-
-      if not computed and prop-node.type isnt \atom
-        throw Error "Expected quoted name of property getter to be an atom"
 
       prop = @compile prop-node
 

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -101,7 +101,7 @@ function-type = (type) -> (params, ...rest) ->
 
 is-atom = (node, name) -> node.type is \atom and node.value is name
 
-unwrap-quote = (node) ->
+maybe-unwrap-quote = (node) ->
   | node.type is \list and node.values.0 `is-atom` \quote =>
     computed : false
     node : node.values.1
@@ -204,7 +204,7 @@ contents =
       if not name?
         throw Error "Expected #{type}ter in property #i to have a name"
 
-      {node, computed} = unwrap-quote name
+      {node, computed} = maybe-unwrap-quote name
 
       unless computed or node.type is \atom
         throw Error "Expected name of #{type}ter in property #i to be a quoted
@@ -253,7 +253,7 @@ contents =
       if not name?
         throw Error "Expected method in property #i to have a name"
 
-      {node, computed} = unwrap-quote name
+      {node, computed} = maybe-unwrap-quote name
 
       unless computed or node.type is \atom
         throw Error "Expected name of method in property #i to be a quoted atom
@@ -311,7 +311,7 @@ contents =
         shorthand : true
 
       | args.length is 2 =>
-        {node, computed} = unwrap-quote args.0
+        {node, computed} = maybe-unwrap-quote args.0
 
         if not computed and node.type isnt \atom
           throw Error "Expected name of property #i to be an expression or
@@ -433,7 +433,7 @@ contents =
 
   \. : do
     join-members = (host, prop) ->
-      {node, computed} = unwrap-quote prop
+      {node, computed} = maybe-unwrap-quote prop
 
       if not computed and node.type isnt \atom
         throw Error "Expected quoted name of property getter to be an atom"

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -455,7 +455,6 @@ contents =
       switch
       | &length is 0 => throw Error "dot called with no arguments"
       | &length is 1 => @compile host
-      | &length is 2 => join-members.call this, (@compile host), &1
       | otherwise =>
         host = @compile host
         for i from 1 til &length

--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -248,7 +248,6 @@ contents =
       value : do
         (function-type \FunctionExpression)
           .apply this, function-macro-arguments-part
-            ..expression = false
 
     compile-method = ([name, ...function-macro-arguments-part]) ->
 
@@ -278,7 +277,6 @@ contents =
       value : do
         (function-type \FunctionExpression)
           .apply this, function-macro-arguments-part
-            ..expression = false
 
     compile-property-list = (args) ->
       | args.length is 0 =>

--- a/src/translate.ls
+++ b/src/translate.ls
@@ -31,8 +31,10 @@ module.exports = (root-env, ast, options={}) ->
            |> (.map statementify)
 
   err = errors program-ast |> reject ({node}) ->
-    # These are valid ES6 nodes, and their errors need to be ignored. See
-    # https://github.com/estools/esvalid/issues/7.
+    # TODO Because esvalid doesn't yet support ES6
+    # https://github.com/estools/esvalid/issues/7 we have to manually ignore
+    # errors to do with properties that have a computed key.  This may miss
+    # some though!
     | node.type is \Property =>
       node.computed and node.key?.type not in <[Identifier Literal]>
     | otherwise => false

--- a/test.ls
+++ b/test.ls
@@ -745,11 +745,15 @@ test "object macro can create getters" ->
   esl '(object (get \'a () (return 1)))'
     ..`@equals` '({\n    get a() {\n        return 1;\n    }\n});'
 
+test "object macro can create getters with empty body" ->
+  esl '(object (get \'a ()))'
+    ..`@equals` '({\n    get a() {\n    }\n});'
+
 test "object macro can create setters" ->
   esl '(object (set \'a (x) (return 1)))'
     ..`@equals` '({\n    set a(x) {\n        return 1;\n    }\n});'
 
-test "object macro can create setters with no body" ->
+test "object macro can create setters with empty body" ->
   esl '(object (set y (x)))'
     ..`@equals` '({\n    set [y](x) {\n    }\n});'
 
@@ -767,9 +771,10 @@ test "object macro can create computed getters and setters" ->
 test "object macro's parts can be ES6 methods" ->
   esl '''
       (object
-        ('a () (return 1))
-        ('b (x) (return (+ x 1)))
-        (c (x y) (return (+ x y 1))))
+        (method 'a () (return 1))
+        (method 'b (x) (return (+ x 1)))
+        (method c (x y) (return (+ x y 1)))
+        (method 'd ())) ; no args, empty method body
       '''
     ..`@equals` """
       ({
@@ -781,6 +786,8 @@ test "object macro's parts can be ES6 methods" ->
           },
           [c](x, y) {
               return x + (y + 1);
+          },
+          d() {
           }
       });
       """
@@ -804,10 +811,10 @@ test "object macro compiles complex ES6 object" ->
         (set (. syms 'Sym) (value)
           ((. wm 'set) this value))
 
-        ('printFoo ()
+        (method 'printFoo ()
           ((. console 'log) (. this 'foo)))
 
-        ('concatFoo (value)
+        (method 'concatFoo (value)
           (return (+ (. this 'foo) value))))
       '''
     ..`@equals` '''

--- a/test.ls
+++ b/test.ls
@@ -856,6 +856,15 @@ test "object macro not-a-quoted-atom in argument raises error" ->
     return
   @fail "No error thrown"
 
+test "object macro setter with bad argument list raises error" ->
+  try
+    esl '(object (set x x))'
+  catch e
+    e.message `@equals` 'Unexpected object macro argument 0: Unexpected setter part (got atom; expected list of parameters)'
+
+    return
+  @fail "No error thrown"
+
 test "macro producing an object literal" ->
   esl "(macro obj (lambda () (return '(object ('a 1)))))
        (obj)"

--- a/test.ls
+++ b/test.ls
@@ -894,6 +894,24 @@ test "object macro getter with arguments raises error" ->
     return
   @fail "No error thrown"
 
+test "object macro method with no name raises error" ->
+  try
+    esl '(object (method))'
+  catch e
+    e.message `@equals` 'Unexpected object macro argument 0: Method has no name or argument list'
+
+    return
+  @fail "No error thrown"
+
+test "object macro method with no argument list raises error" ->
+  try
+    esl '(object (method \'x))'
+  catch e
+    e.message `@equals` 'Unexpected object macro argument 0: Expected method \'x\' to have an argument list'
+
+    return
+  @fail "No error thrown"
+
 test "macro producing an object literal" ->
   esl "(macro obj (lambda () (return '(object ('a 1)))))
        (obj)"

--- a/test.ls
+++ b/test.ls
@@ -749,6 +749,10 @@ test "object macro can create setters" ->
   esl '(object (set \'a (x) (return 1)))'
     ..`@equals` '({\n    set a(x) {\n        return 1;\n    }\n});'
 
+test "object macro can create setters with no body" ->
+  esl '(object (set y (x)))'
+    ..`@equals` '({\n    set [y](x) {\n    }\n});'
+
 test "object macro can create computed getters and setters" ->
   esl '(object (get a ()) (set a (x)))'
     ..`@equals` '''

--- a/test.ls
+++ b/test.ls
@@ -869,6 +869,24 @@ test "object macro setter with bad argument list raises error" ->
     return
   @fail "No error thrown"
 
+test "object macro setter with no arguments raises error" ->
+  try
+    esl '(object (set x ()))'
+  catch e
+    e.message `@equals` 'Unexpected object macro argument 0: Expected setter to have exactly one parameter (got 0)'
+
+    return
+  @fail "No error thrown"
+
+test "object macro getter with arguments raises error" ->
+  try
+    esl '(object (get x (y)))'
+  catch e
+    e.message `@equals` 'Unexpected object macro argument 0: Expected getter to have no parameters (got 1)'
+
+    return
+  @fail "No error thrown"
+
 test "macro producing an object literal" ->
   esl "(macro obj (lambda () (return '(object ('a 1)))))
        (obj)"

--- a/test.ls
+++ b/test.ls
@@ -717,6 +717,10 @@ test "array macro can be empty" ->
   esl "(array)"
     ..`@equals` "[];"
 
+test "object macro can be empty" ->
+  esl "(object)"
+    ..`@equals` "({});"
+
 test "object macro produces object expression" ->
   esl "(object ('a 1) ('b 2))"
     ..`@equals` "({\n    a: 1,\n    b: 2\n});"
@@ -827,6 +831,30 @@ test "object macro compiles complex ES6 object" ->
         }
     });
     '''
+
+test "object macro empty list argument raises error" ->
+  try
+    esl '(object ())'
+  catch e
+    e.message `@equals` "Unexpected object macro argument 0: Got empty list (expected list to have contents)"
+    return
+  @fail "No error thrown"
+
+test "object macro non-list argument raises error" ->
+  try
+    esl '(object "hi")'
+  catch e
+    e.message `@equals` "Unexpected object macro argument 0: Got string (expected list)"
+    return
+  @fail "No error thrown"
+
+test "object macro not-a-quoted-atom in argument raises error" ->
+  try
+    esl '(object ((a x)))'
+  catch e
+    e.message `@equals` "Unexpected object macro argument 0: Invalid single-element list (expected a pattern of (quote <atom>))"
+    return
+  @fail "No error thrown"
 
 test "macro producing an object literal" ->
   esl "(macro obj (lambda () (return '(object ('a 1)))))


### PR DESCRIPTION
- refactored
- added tests
- used `method` atom to denote method properties (see https://github.com/isiahmeadows/eslisp/commit/98ddff3c0f7913724c785b6b88fb0c90a8fe166b)

It's probably administratively neater to merge this into your `property` branch so everything about it stays in [the same PR](https://github.com/anko/eslisp/pull/41) and we stay on the same page about what's happening.

I still see the issue that `{ set : 5 }` can't be expressed, because that `(object (set (a)))`→`({ set [a](b) {} })`, but this is progress.
